### PR TITLE
add functionality to handle antimeridian in offset polygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a functionality to deal with polygons crossing the antimeridian (180° longitude), especially in the context of ofsetting regions. The implementation is based on the implementation in the python library at https://github.com/gadomski/antimeridian, though it's simplified to only work on a subset of cases for the moment.
 
-- Placeholder
+### Changed
+- The `borders` is now the one defined in `CountriesBorders.jl` and is simply extended in GeoGrids (instead of replacing it with a local function of the same name)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a functionality to deal with polygons crossing the antimeridian (180° longitude), especially in the context of ofsetting regions. The implementation is based on the implementation in the python library at https://github.com/gadomski/antimeridian, though it's simplified to only work on a subset of cases for the moment.
+- Added methods for `PlotlyBase.scattergeo` and `CountriesBorders.extract_plot_coords` to work with `MultiBorder`, `PolyBorder` and `AbstractRegion`
 
 ### Changed
 - The `borders` is now the one defined in `CountriesBorders.jl` and is simply extended in GeoGrids (instead of replacing it with a local function of the same name)

--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -6,6 +6,7 @@ using Unitful: ustrip
 using Meshes: vertices, rings, Multi, Ngon, 🌐, WGS84Latest
 
 using GeoGrids
+using GeoGrids: extract_plot_coords, MultiBorder, PolyBorder, AbstractRegion
 
 const DEFAULT_CELL_CONTOUR = (;
     mode="lines",
@@ -411,5 +412,8 @@ function GeoGrids.plot_unitarysphere(points_cart; kwargs_scatter=(;), kwargs_lay
     # Plot([sphere,markers],layout)
     plotly_plot([sphere, markers], layout)
 end
+
+PlotlyBase.scattergeo(b::Union{<:PolyBorder, <:MultiBorder}; kwargs...) = scattergeo(; extract_plot_coords(b)..., mode = "lines")
+PlotlyBase.scattergeo(b::AbstractRegion; kwargs...) = scattergeo(; extract_plot_coords(b)..., mode = "lines")
 
 end # module PlotlyBaseExt

--- a/src/GeoGrids.jl
+++ b/src/GeoGrids.jl
@@ -5,7 +5,7 @@ using Clipper
 using CoordRefSystems
 using CoordRefSystems: Deg
 using CountriesBorders
-using CountriesBorders: borders, cartesian_geometry, latlon_geometry, change_geometry
+using CountriesBorders: borders, cartesian_geometry, latlon_geometry, change_geometry, extract_plot_coords
 using CountriesBorders.GeoTablesConversion: LATLON, CART, POLY_LATLON, POLY_CART, MULTI_LATLON, MULTI_CART, RING_LATLON, RING_CART
 using Dictionaries
 using LinearAlgebra

--- a/src/interface_func.jl
+++ b/src/interface_func.jl
@@ -96,3 +96,8 @@ Meshes.centroid(d::PolyRegionOffset) = centroid(Cartesian, d.domain)
 
 ## CountriesBorders.extract_countries()
 CountriesBorders.extract_countries(r::GeoRegion) = r.domain
+
+## extract_plot_coords
+CountriesBorders.extract_plot_coords(b::Union{PolyBorder, MultiBorder}) = extract_plot_coords(borders(LatLon, b))
+
+CountriesBorders.extract_plot_coords(r::AbstractRegion) = extract_plot_coords(r.domain)

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -71,3 +71,12 @@ end
     # Test with custom title and layout options
     @test plot_geo_poly(poly; title="Custom Polygon Plot", kwargs_layout=(width=800, height=600)) isa Plot
 end
+
+@testitem "scattergeo" tags = [:plotting] begin
+    using PlotlyBase
+
+    offset_region = GeoRegionOffset(; admin = "Spain", delta = 100e3)
+
+    # This is just a coverage test and sanity check to spot errors. It is not really testing functionality
+    @test scattergeo(offset_region) == scattergeo(offset_region.domain)
+end


### PR DESCRIPTION
This PR adds some functionality to split polygons crossing the antimeridian, and uses this functionality when creating offset polygons.

Implementation is loosely based on the python library at https://github.com/gadomski/antimeridian

Additionally, it extends some plotting helper functions (i.e. `PlotlyBase.scattergeo` and `CountriesBorders.extract_plot_coords`) to work on types defined within this package