### PR TITLE
Add additional AbstractRegion subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Two new subtypes of `AbstractRegion` have been added (check docstrings for more details):
+  - `HotspotRegion` which is a region representing all points within a certain distance (radius) of a point.
+  - `MultiRegion` which is a region encompassing multiple polyareas, and that can be constructed with a vector of `AbstractRegion`s as input.
+
+### Changed
+- The `LatBeltRegion` now has the lim field which is a `NTuple{2, Deg{Float32}}` to be concrete and has an implementation of `bboxes` and `polyareas` to simpify plotting and inclusion within a `MultiRegion`.
+
 ## [0.5.7] - 2025-03-08
 
 ### Changed

--- a/src/GeoGrids.jl
+++ b/src/GeoGrids.jl
@@ -33,6 +33,7 @@ include("plot_func.jl")
 export AbstractRegion, GlobalRegion, GeoRegion, PolyRegion, LatBeltRegion,
     GeoRegionOffset, PolyRegionOffset,
     MultiBorder, PolyBorder,
+    HotSpotRegion, MultiRegion,
     AbstractTiling, ICO, HEX, H3,
     EO
     # UnitfulAngleType, UnitfulAngleQuantity, ValidAngle,

--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -156,6 +156,72 @@ end
 
 LatBeltRegion(; name::String="region_name", lim) = LatBeltRegion(name, lim)
 
+
+# HotSpotRegion <: AbstractRegion
+"""
+    HotSpotRegion{P} <: AbstractRegion
+
+Type representing a hot spot region, which is defined as the set of points which are less than `radius` distance from a given `center` in LatLon CRS.
+
+Fields:
+- `name::String`: Name identifying the hot spot
+- `center::POINT_LATLON{P}`: Center of the hot spot
+- `radius::Float64`: Radius of the hot spot [m]
+- `domain::PolyBorder{P}`: Polygon identifying the polygon in latlon which represents a _circle_ of specified radius from the center
+
+# Constructor
+    HotSpotRegion(; name::String, center::Union{LATLON, POINT_LATLON}, radius::Number)
+
+Create a HotSpotRegion from a name, a center and a radius.
+"""
+struct HotSpotRegion{P} <: AbstractRegion
+    "Name identifying the hot spot"
+    name::String
+    "Center of the hot spot"
+    center::POINT_LATLON{P}
+    "Radius of the hot spot [m]"
+    radius::Float64
+    "Polygon identifying the polygon in latlon which represents a _circle_ of specified radius from the center"
+    domain::PolyBorder{P}
+end
+function HotSpotRegion(; name::String, center::Union{LATLON, POINT_LATLON}, radius::Number)
+    c = center isa LATLON ? Point(center) : center
+    circ_poly = gen_circle_pattern(c, radius; n = 51) |> only
+    domain = PolyBorder(circ_poly[1:end-1] |> PolyArea)
+    return HotSpotRegion{floattype(c)}(name, c, radius, domain)
+end
+
+"""
+    MultiRegion{P} <: AbstractRegion
+
+Type representing a region which is defined as the union of multiple PolyAreas.
+
+Fields:
+- `name::String`: Name identifying the multi region
+- `domain::MultiBorder{P}`: MultiPolygon identifying the various regions included in the multi region
+
+# Constructor
+    MultiRegion(areas::Vector; name::String)
+
+The constructor takes a vector of polyareas, Multi, or other AbstractRegions and creates a single MultiBorder which encompasses all the polyareas of the provided `areas`.
+"""
+@kwdef struct MultiRegion{P} <: AbstractRegion
+    "Name identifying the multi region"
+    name::String
+    "List of Polygons identifying the various regions included in the multi region"
+    domain::MultiBorder{P}
+end
+function MultiRegion(areas::Vector; name::String)
+    # We convert all polygons to Float32 machine precision
+    f(reg) = Iterators.map(change_floattype(Float32), polyareas(reg))
+    f(reg::Union{POLY_LATLON, MULTI_LATLON}) = cartesian_geometry(reg) |> f
+
+    multi_cart = Iterators.flatten((f(area) for area in areas)) |> Multi
+    multi_latlon = latlon_geometry(multi_cart)
+    domain = MultiBorder(multi_latlon, multi_cart)
+    return MultiRegion(name, domain)
+end
+
 ## Define Tessellation Types
 abstract type AbstractTiling end
 

--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -131,7 +131,7 @@ Fields:
 """
 mutable struct LatBeltRegion <: AbstractRegion
     name::String
-    lim::Tuple{ValidAngle,ValidAngle} # [°]
+    lim::Tuple{Deg{Float64},Deg{Float64}} # [°]
 
     function LatBeltRegion(name::String, lim::Tuple{ValidAngle,ValidAngle})
         # Inputs validation    

--- a/src/helper_func.jl
+++ b/src/helper_func.jl
@@ -91,3 +91,11 @@ function _add_angular_offset(inputθϕ, offsetθϕ)
 
     return (θ=θ, ϕ=ϕ) # [deg] ALBERTO: ?? Is it deg though? as the acos and atan return values in radians
 end
+
+# This is a function that will force a POLY_CART to have a specific machine type
+function change_floattype(poly::POLY_CART, T::Type{<:Real})
+    map(rings(poly)) do r
+        map(p -> to_cart_point(p, T), vertices(r)) |> Ring
+    end |> splat(PolyArea)
+end
+change_floattype(T::Type{<:Real}) = p -> change_floattype(p, T)

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -135,6 +135,29 @@ end
     @test centroid(LatLon, poly.domain) == testPoint_latlon
 end
 
+@testitem "HotSpotRegion" tags = [:interface] begin
+    using GeoGrids: constants
+    degkm = deg2rad(1) * constants.Re_mean
+    hr = HotSpotRegion(; name = "hotspot", center = LatLon(40°, 10°), radius = degkm)
+    @test hr isa HotSpotRegion
+    @test LatLon(40,10) in hr
+    @test LatLon(40 + 0.99,10) in hr
+    @test LatLon(40 + 1.01,10) ∉ hr
+end
+
+@testitem "MultiRegion" tags = [:interface] begin
+    reg = GeoRegion(name="ITA", admin="Italy")
+    poly = PolyArea(map(Point, [LatLon(10°, -5°), LatLon(10°, 15°), LatLon(27°, 15°), LatLon(27°, -5°)]))
+    lbr = LatBeltRegion(; name = "lbr", lim = (-30°, -29°))
+    hr = HotSpotRegion(; name = "hr", center = LatLon(-40°, 10°), radius = 500e3)
+    mr = MultiRegion([reg, poly, lbr, hr]; name = "MultiRegion")
+    @test mr isa MultiRegion
+    @test centroid(LatLon, reg) in mr
+    @test centroid(poly) in mr
+    @test LatLon(-29.5, 0) in mr
+    @test LatLon(-40, 10) in mr
+end
+
 ## Helpers
 @testitem "Helper Functions" tags = [:general] begin
     r = GeoRegion(name="ITA", admin="Italy")


### PR DESCRIPTION
This PR adds the following additional AbstractRegion concrete subtypes:
  - `HotspotRegion` which is a region representing all points within a certain distance (radius) of a point.
  - `MultiRegion` which is a region encompassing multiple polyareas, and that can be constructed with a vector of `AbstractRegion`s as input.

It also changes some inner details of LatBeltRegion to make it more compliant to the interface and simplify its inclusion as input for `MultiRegion`