### PR TITLE
generalize plotting and small tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed some issues with Plotting introduced with CountriesBorders.jl 0.4.8 that are now fixed with 0.4.9.
 - Removed some code duplication and overspecified arguments in function signatures for internal code.
+- The internal `gen_circle_pattern` function now returns a number of points which respects the `n` input keyword argument.
 
 
 ## [0.5.8] - 2025-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- The `plot_geo_poly` function now has a `single_trace` keyword argument to allow for plotting multiple polyareas provided as a single trace (default to `false`).
+- The `plot_geo_poly` function now also supports generic iterables of PolyAreas and has specific methods to be used with `AbtractRegion` inputs.
+- The `plot_geo_cells` function now has a `color_contours` keyword argument to control whether the cell contours are also colored when providing a `color` vector(default to `true`).
+
+
 ## [0.5.8] - 2025-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed some issues with Plotting introduced with CountriesBorders.jl 0.4.8 that are now fixed with 0.4.9.
+- Removed some code duplication and overspecified arguments in function signatures for internal code.
 
 
 ## [0.5.8] - 2025-03-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `plot_geo_poly` function now also supports generic iterables of PolyAreas and has specific methods to be used with `AbtractRegion` inputs.
 - The `plot_geo_cells` function now has a `color_contours` keyword argument to control whether the cell contours are also colored when providing a `color` vector(default to `true`).
 
+### Fixed
+- Fixed some issues with Plotting introduced with CountriesBorders.jl 0.4.8 that are now fixed with 0.4.9.
+
 
 ## [0.5.8] - 2025-03-20
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoGrids"
 uuid = "22c7c615-cf67-4787-b800-cc81b4f1a63f"
 authors = ["mconti"]
-version = "0.5.8"
+version = "0.5.9-DEV"
 
 [deps]
 AngleBetweenVectors = "ec570357-d46e-52ed-9726-18773498274d"
@@ -29,7 +29,7 @@ PlotlyBaseExt = "PlotlyBase"
 AngleBetweenVectors = "0.3.0"
 Clipper = "0.6.3"
 CoordRefSystems = "0.13 - 0.16"
-CountriesBorders = "0.4.6"
+CountriesBorders = "0.4.9"
 Dictionaries = "0.4.2"
 Graphs = "1.12.0"
 Distances = "0.10.12"

--- a/README.md
+++ b/README.md
@@ -116,17 +116,9 @@ The function checks if each point falls inside the given region using the approp
 
 This function filters a vector of points based on whether they fall within a specified region. It returns a new vector containing only the points that are inside the region.
 
-    filter_points_fast(points::AbstractVector{<:Union{LatLon, Point{🌐,<:LatLon{WGS84Latest}}}}, domain::AbstractRegion) -> Vector{eltype(points)}
-
-This is a faster version of `filter_points` that uses a different algorithm for checking point inclusion. It's particularly efficient for large numbers of points.
-
     group_by_domain(points::AbstractVector{<:Union{LatLon, Point{🌐,<:LatLon{WGS84Latest}}}}, domains::AbstractVector{<:AbstractRegion}) -> Dictionary{String, Vector{eltype(points)}}
 
 This function groups points based on which region they belong to. It returns a dictionary where the keys are names of the domains, and the values are vectors of points that fall within each domain.
-
-    group_by_domain_fast(points::AbstractVector{<:Union{LatLon, Point{🌐,<:LatLon{WGS84Latest}}}}, domains::AbstractVector{<:AbstractRegion}) -> Dictionary{String, Vector{eltype(points)}}
-
-This is a faster version of `group_by_domain` that uses the same efficient algorithm as `filter_points_fast`.
 
 ### Examples:
 

--- a/docs/src/coloring.md
+++ b/docs/src/coloring.md
@@ -18,3 +18,10 @@ colors = color_greedy(centers, 50e3, 4)
 plot = plot_geo_cells(centers, tiles; colors, title="Hexagonal Tessellation with Colors of Italy", kwargs_layout=(;geo_fitbounds="locations"))
 to_documenter(plot) # hide
 ```
+
+Alternatively, the contours of the colors of the cells can be limited to simply the number of the cells by passing the keyword argument `color_contours=false`.
+```@example plot
+plot = plot_geo_cells(centers, tiles; colors, color_contours=false, title="Hexagonal Tessellation with Colors of Italy", kwargs_layout=(;geo_fitbounds="locations"))
+to_documenter(plot) # hide
+```
+

--- a/docs/src/regions/filtering.md
+++ b/docs/src/regions/filtering.md
@@ -23,22 +23,6 @@ plot = plot_geo_points(filtered; title="Points Filtered to Equatorial Belt")
 to_documenter(plot) # hide
 ```
 
-## Fast Filtering
-
-For large point sets, GeoGrids.jl provides optimized filtering through `filter_points_fast`:
-
-```julia
-# Create a polygon region
-region = PolyRegion(domain=[
-    LatLon(10°, -5°), 
-    LatLon(10°, 15°), 
-    LatLon(27°, 15°), 
-    LatLon(27°, -5°)
-])
-points = rectgrid(1)[:]  # Dense grid
-filtered = filter_points_fast(points, region)
-```
-
 ## Grouping Points by Region
 
 Sometimes you need to categorize points based on which regions they fall into. The `group_by_domain` function handles this:

--- a/docs/src/regions/regions.md
+++ b/docs/src/regions/regions.md
@@ -82,7 +82,7 @@ to_documenter(plot) # hide
 
 ```@example plot
 region = HotSpotRegion(center=LatLon(30, 40), radius=1000e3)
-plot = scattergeo(region) |> Plot
+plot = plot_geo_poly(region; title = "HotSpotRegion", kwargs_layout=(;geo_fitbounds="locations"))
 to_documenter(plot) # hide
 ```
 
@@ -94,7 +94,7 @@ to_documenter(plot) # hide
 hr = HotSpotRegion(center=LatLon(30, 40), radius=1000e3)
 italy = GeoRegion(;admin="Italy")
 mr = MultiRegion([hr, italy])
-plot = scattergeo(mr) |> Plot
+plot = plot_geo_poly(mr; title = "MultiRegion", kwargs_layout=(;geo_fitbounds="locations"))
 to_documenter(plot) # hide
 ```
 
@@ -106,7 +106,7 @@ to_documenter(plot) # hide
 box = BoxBorder(LatLon(30, 10), LatLon(45, 35)) # We only keep the portions of the regions that are between 30-45 latitude and 10-35 longitude
 reg = GeoRegion(;continent = "Europe")
 cr = ClippedRegion(reg, box)
-plot = scattergeo(cr) |> Plot
+plot = plot_geo_poly(cr; title = "Clipped Region", kwargs_layout=(;geo_fitbounds="locations"))
 to_documenter(plot) # hide
 ```
 

--- a/src/GeoGrids.jl
+++ b/src/GeoGrids.jl
@@ -5,7 +5,7 @@ using Clipper
 using CoordRefSystems
 using CoordRefSystems: Deg, RevolutionEllipsoid, Cartesian
 using CountriesBorders
-using CountriesBorders: borders, cartesian_geometry, latlon_geometry, change_geometry, geom_iterable, bboxes, polyareas, in_exit_early, to_cart_point, VALID_CRS, floattype, to_latlon_point
+using CountriesBorders: borders, cartesian_geometry, latlon_geometry, change_geometry, geom_iterable, bboxes, polyareas, in_exit_early, to_cart_point, VALID_CRS, floattype, to_latlon_point, to_raw_coords
 using CountriesBorders.GeoTablesConversion: LATLON, CART, POLY_LATLON, POLY_CART, MULTI_LATLON, MULTI_CART, RING_LATLON, RING_CART, POINT_LATLON, BOX_CART, DOMAIN, BOX_LATLON
 using Dictionaries
 using Distances: Distances, Metric, result_type

--- a/src/basic_types.jl
+++ b/src/basic_types.jl
@@ -248,6 +248,7 @@ function MultiRegion(areas::Vector; name::String = "")
     # We convert all polygons to Float32 machine precision, use the full constructor to create a different machine type
     T = Float32
     f(reg) = Iterators.map(change_geometry(LatLon, T), polyareas(reg))
+    f(b::BorderGeometry) = Iterators.map(change_geometry(LatLon, T), polyareas(b))
     f(reg::Geometry) = (change_geometry(LatLon, T, reg), )
 
     multi_latlon = Iterators.flatten((f(area) for area in areas)) |> Multi

--- a/src/filtering_func.jl
+++ b/src/filtering_func.jl
@@ -16,11 +16,13 @@ indices of the filtered points (wrt the input).
 - A vector of points that fall within the specified domain, subsection of the \
 input vector. The output is of the same type as the input.
 """
-function filter_points(points::AbstractVector{<:Union{LATLON, POINT_LATLON}}, domain::Union{AbstractRegion, PolyBorder, MultiBorder}) 
+function filter_points(points::AbstractVector{<:Union{LATLON, POINT_LATLON}}, domain::Union{AbstractRegion, BorderGeometry}) 
+    domain isa GlobalRegion && return points
     return filter(in(domain), points)
 end
 
-function filter_points(points::AbstractVector{<:Union{LATLON, POINT_LATLON}}, domain::Union{AbstractRegion, PolyBorder, MultiBorder}, ::EO) 
+function filter_points(points::AbstractVector{<:Union{LATLON, POINT_LATLON}}, domain::Union{AbstractRegion, BorderGeometry}, ::EO) 
+    domain isa GlobalRegion && return (points, eachindex(points) |> collect)
     # We can't just use `in(domain)` as function as that goes through a different dispatch method of `findall` which doesn't work
     indices = findall(p -> p in domain, points)
     return points[indices], indices

--- a/src/helper_func.jl
+++ b/src/helper_func.jl
@@ -92,20 +92,6 @@ function _add_angular_offset(inputθϕ, offsetθϕ)
     return (θ=θ, ϕ=ϕ) # [deg] ALBERTO: ?? Is it deg though? as the acos and atan return values in radians
 end
 
-# This function takes a box and constructs the corresponding PolyArea by oversampling the lon to avoid artifacts while displaying the PolyArea on scattergeo
-function box_to_poly_oversample(b::Union{BOX_CART, BOX_LATLON}, lon_dist = 5)
-	lo, hi = extrema(b) .|> coords .|> CoordRefSystems.raw
-    lo_lon, lo_lat = lo
-    hi_lon, hi_lat = hi
-    f = to_cart_point
-	Δlon = hi_lon - lo_lon
-    # We have points in lon distanced by around 5° mostly to avoid problems in plotting on scattergeo
-    nlon = max(2, ceil(Int, Δlon / lon_dist))
-	hi_gen = [f(LatLon(hi_lat, lon)) for lon in range(lo_lon, hi_lon, nlon)]
-	lo_gen = [f(LatLon(lo_lat, lon)) for lon in range(hi_lon, lo_lon, nlon)]
-    p = Ring(vcat(hi_gen, lo_gen)) |> PolyArea
-end
-
 # This function is used to take a MULTI_CART or Region and a clipping mask and create a MultiBorder obtained by clipping with the mask using the Sutherland-Hodgman algorithm
 function clipped_multiborder(original::MULTI_CART{P}, mask::Union{BoxBorder{P}, PolyBorder{P}}) where P
     # We iterate over all polygons, converting everything to Float32 precision

--- a/src/interface_func.jl
+++ b/src/interface_func.jl
@@ -34,15 +34,11 @@ function CountriesBorders.borders(crs::VALID_CRS, r::LatBeltRegion)
 end
 
 # polyareas
-function CountriesBorders.polyareas(b::BoxBorder)
-    p = box_to_poly_oversample(borders(Cartesian, b))
-    return (p, )
-end
+CountriesBorders.polyareas(b::BoxBorder) = polyareas(b.cart)
 CountriesBorders.polyareas(r::AbstractRegion) = polyareas(r.domain)
 function CountriesBorders.polyareas(r::LatBeltRegion) 
     b = borders(Cartesian, r)
-    p = box_to_poly_oversample(b)
-    return (p, )
+    return polyareas(b)
 end
 
 # bboxes

--- a/src/interface_func.jl
+++ b/src/interface_func.jl
@@ -1,14 +1,12 @@
 ## Define Getters
-get_lat(p::Point{𝔼{2},<:Cartesian2D{WGS84Latest}}) = coords(p).y |> ustrip |> Deg # LAT is Y
-get_lat(p::Point{🌐,<:LatLon{WGS84Latest}}) = coords(p).lat
-get_lat(p::LatLon) = p.lat
-
-get_lon(p::Point{𝔼{2},<:Cartesian2D{WGS84Latest}}) = coords(p).x |> ustrip |> Deg # LON is X
-get_lon(p::Point{🌐,<:LatLon{WGS84Latest}}) = coords(p).lon
-get_lon(p::LatLon) = p.lon
+get_lat(p) = to_raw_coords(p)[2] |> Deg 
+get_lon(p) = to_raw_coords(p)[1] |> Deg 
 
 CountriesBorders.floattype(r::AbstractRegion) = return floattype(r.domain)
 CountriesBorders.floattype(::LatBeltRegion) = return Float64
+
+CountriesBorders.latlon_geometry(T::Type{<:Real}, b::BorderGeometry) = latlon_geometry(T, b.latlon)
+CountriesBorders.cartesian_geometry(T::Type{<:Real}, b::BorderGeometry) = cartesian_geometry(T, b.cart)
 
 ## borders()
 # Define borders for PolyBorder

--- a/src/tessellation_func.jl
+++ b/src/tessellation_func.jl
@@ -97,34 +97,13 @@ See also: [`_adapted_icogrid()`](@ref), [`icogrid()`](@ref),
 [`filter_points()`](@ref), [`GeoRegion`](@ref), [`LatBeltRegion`](@ref),
 [`PolyRegion`](@ref), [`GlobalRegion`](@ref), [`ICO`](@ref)
 """
-function generate_tesselation(region::GlobalRegion, radius::Number, type::ICO; refRadius::Number=constants.Re_mean)
-    return _adapted_icogrid(radius; refRadius, correctionFactor=type.correction)
-end
-
-function generate_tesselation(region::GlobalRegion, radius::Number, type::ICO, ::EO; refRadius::Number=constants.Re_mean)
-    # Generate the tassellation centroids.
-    centroids = _adapted_icogrid(radius; refRadius, correctionFactor=type.correction)
-
-    if type.pattern == :hex # Hexagonal pattern
-        # Create the tasselation from all the centroids.
-        mesh = _tesselate(centroids)
-        # Create the hexagonal pattern from all centroids.
-        hexagons = gen_hex_pattern(centroids, collect(1:length(centroids)), mesh)
-        return centroids, hexagons
-    else # Circular pattern
-        # Create the circular pattern from all the centroids.
-        circles = gen_circle_pattern(centroids, radius; refRadius, n=20)
-        return centroids, circles
-    end
-end
-
-function generate_tesselation(region::Union{LatBeltRegion,GeoRegion,PolyRegion,GeoRegionOffset,PolyRegionOffset}, radius::Number, type::ICO; refRadius::Number=constants.Re_mean)
+function generate_tesselation(region::AbstractRegion, radius::Number, type::ICO; refRadius::Number=constants.Re_mean)
     centroids = _adapted_icogrid(radius; refRadius, correctionFactor=type.correction)
 
     return filter_points(centroids, region)
 end
 
-function generate_tesselation(region::Union{LatBeltRegion,GeoRegion,PolyRegion,GeoRegionOffset,PolyRegionOffset}, radius::Number, type::ICO, ::EO; refRadius::Number=constants.Re_mean)
+function generate_tesselation(region::AbstractRegion, radius::Number, type::ICO, ::EO; refRadius::Number=constants.Re_mean)
     # Generate the tassellation centroids.
     centroids = _adapted_icogrid(radius; refRadius, correctionFactor=type.correction)
 
@@ -145,7 +124,7 @@ function generate_tesselation(region::Union{LatBeltRegion,GeoRegion,PolyRegion,G
     end
 end
 
-function generate_tesselation(region::Union{GlobalRegion,LatBeltRegion,GeoRegion,PolyRegion,GeoRegionOffset,PolyRegionOffset}, radius::Number, type::H3; refRadius::Number=constants.Re_mean)
+function generate_tesselation(::AbstractRegion, radius::Number, type::H3; refRadius::Number=constants.Re_mean)
     error("H3 tassellation is not yet implemented in this version...")
 end
 
@@ -363,7 +342,6 @@ function _tesselate(points::AbstractVector{<:Point{🌐,<:LatLon{WGS84Latest}}},
     converted = map(x -> Meshes.flat(x), points)
     return tesselate(PointSet(converted), method)
 end
-_tesselate(point::Point{🌐,<:LatLon{WGS84Latest}}; kwargs...) = _tesselate([point]; kwargs...)
 
 """
     gen_circle_pattern(centers::AbstractVector{Point{🌐,<:LatLon{WGS84Latest}}}, radius::Number; refRadius::Number=constants.Re_mean, n::Int=20) -> Vector{Vector{Point{🌐,<:LatLon{WGS84Latest}}}

--- a/src/tessellation_func.jl
+++ b/src/tessellation_func.jl
@@ -51,7 +51,9 @@ function generate_tesselation(region::AbstractRegion, radius::Number, type::HEX,
     return _tessellation_with_contours(centroids, region, type.pattern; refRadius, radius)
 end
 
-generate_tesselation(region::GlobalRegion, radius::Number, type::HEX, args...; kwargs...) = throw(ArgumentError("GlobalRegion is not supported for hexagonal tesselation"))
+# Throw for global region
+generate_tesselation(region::GlobalRegion, radius::Number, type::HEX, ::EO; kwargs...) = throw(ArgumentError("GlobalRegion is not supported for hexagonal tesselation"))
+generate_tesselation(region::GlobalRegion, radius::Number, type::HEX; kwargs...) = throw(ArgumentError("GlobalRegion is not supported for hexagonal tesselation"))
 
 """
     generate_tesselation(region::GlobalRegion, radius::Number, type::ICO; refRadius::Number=constants.Re_mean) -> AbstractVector{<:LatLon}

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -192,7 +192,7 @@ end
 end
 
 @testitem "CountriesBorders methods" tags = [:interface] begin
-    using GeoGrids: floattype, bboxes, polyareas, borders, POLY_CART, BOX_CART
+    using GeoGrids: floattype, bboxes, polyareas, borders, POLY_CART, BOX_CART, BOX_LATLON, latlon_geometry, cartesian_geometry
 
     r = GeoRegion(name="ITA", admin="Italy")
     llr = LatBeltRegion(; name = "llr", lim = (-30°, -29°))
@@ -208,4 +208,8 @@ end
     end
 
     @test centroid(box) == centroid(borders(Cartesian, box))
+
+    bb = BoxBorder(LatLon(0, 0), LatLon(90, 99))
+    @test cartesian_geometry(Float32, bb) isa BOX_CART
+    @test latlon_geometry(Float32, bb) isa BOX_LATLON
 end

--- a/test/plots.jl
+++ b/test/plots.jl
@@ -69,12 +69,25 @@ end
     multi_border = MultiBorder(multi)
     @test plot_geo_poly(multi_border) isa Plot
 
+    p1 = plot_geo_poly(multi_border)
+    p2 = plot_geo_poly(multi_border, single_trace=true)
+    @test length(p1.data) > length(p2.data)
+
     # Test with different camera views
     @test plot_geo_poly(poly; camera=:threedim) isa Plot
     @test plot_geo_poly(polys; camera=:threedim) isa Plot
 
     # Test with custom title and layout options
     @test plot_geo_poly(poly; title="Custom Polygon Plot", kwargs_layout=(width=800, height=600)) isa Plot
+
+    # Test with a box
+    bb = BoxBorder(LatLon(0, 0), LatLon(1, 1))
+    lbr = LatBeltRegion("test", (0, 1))
+    hr = HotSpotRegion( ; center = LatLon(0, 0), radius = 100e3)
+    mr = MultiRegion([lbr, hr, bb])
+    for r in (bb, lbr, hr, mr)
+        @test plot_geo_poly(r) isa Plot
+    end
 end
 
 @testitem "scattergeo" tags = [:plotting] begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,10 @@ include("offsetting.jl")
     Aqua.test_ambiguities(GeoGrids)
 end
 
-@testitem "JET" begin
+@testitem "JET" tags=[:jet] begin
     using JET
     report_package("GeoGrids")
 end
 
-@run_package_tests verbose = true
+# @run_package_tests verbose = true
+@run_package_tests verbose = true filter=ti->!(:jet in ti.tags)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,5 +18,4 @@ end
     report_package("GeoGrids")
 end
 
-# @run_package_tests verbose = true
-@run_package_tests verbose = true filter=ti->!(:jet in ti.tags)
+@run_package_tests verbose = true

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -319,6 +319,19 @@ end
     end
 end
 
+@testitem "Misc coverage" begin
+    using GeoGrids: gen_circle_pattern, get_lat
+
+    # We test wrapping around poles
+    pts = gen_circle_pattern(LatLon(90, 0), 1000e3) |> first
+    lat = get_lat(first(pts))
+    @test all(p -> get_lat(p) ≈ lat, pts)
+
+    pts = gen_circle_pattern(LatLon(-90, 0), 1000e3) |> first
+    lat = get_lat(first(pts))
+    @test all(p -> get_lat(p) ≈ lat, pts)
+end
+
 @testitem "Test missing Functions" tags = [:tesselation] begin
     reg = GlobalRegion()
     @test_throws "H3 tassellation is not yet implemented in this version..." generate_tesselation(reg, 10.0, H3())

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -320,7 +320,7 @@ end
 end
 
 @testitem "Misc coverage" begin
-    using GeoGrids: gen_circle_pattern, get_lat
+    using GeoGrids: gen_circle_pattern, get_lat, _wrap_latlon
 
     # We test wrapping around poles
     pts = gen_circle_pattern(LatLon(90, 0), 1000e3) |> first
@@ -330,9 +330,14 @@ end
     pts = gen_circle_pattern(LatLon(-90, 0), 1000e3) |> first
     lat = get_lat(first(pts))
     @test all(p -> get_lat(p) ≈ lat, pts)
+
+    @test _wrap_latlon(100, 0) == (80, 180)
+    @test _wrap_latlon(-100, 0) == (-80, 180)
 end
 
 @testitem "Test missing Functions" tags = [:tesselation] begin
     reg = GlobalRegion()
     @test_throws "H3 tassellation is not yet implemented in this version..." generate_tesselation(reg, 10.0, H3())
+
+    @test_throws ArgumentError generate_tesselation(GlobalRegion(), 10.0, HEX())
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -340,4 +340,5 @@ end
     @test_throws "H3 tassellation is not yet implemented in this version..." generate_tesselation(reg, 10.0, H3())
 
     @test_throws ArgumentError generate_tesselation(GlobalRegion(), 10.0, HEX())
+    @test_throws ArgumentError generate_tesselation(GlobalRegion(), 10.0, HEX(), EO())
 end

--- a/test/tesselation.jl
+++ b/test/tesselation.jl
@@ -1,3 +1,25 @@
+@testsnippet setup_tessellation begin
+    using GeoGrids
+    using GeoGrids: constants, to_raw_coords
+
+    function haversine(p1, p2; refRadius = constants.Re_mean)
+        # Convert latitude and longitude to radians
+        lon1, lat1 = to_raw_coords(p1) .|> deg2rad
+        lon2, lat2 = to_raw_coords(p2) .|> deg2rad
+
+        # Calculate differences in longitude and latitude
+        Δlon = lon2 - lon1
+        Δlat = lat2 - lat1
+
+        # Calculate the great-circle distance
+        a = sin(Δlat / 2)^2 + cos(lat1) * cos(lat2) * sin(Δlon / 2)^2
+        c = 2 * atan(sqrt(a), sqrt(1 - a))
+
+        # Return the distance in kilometers
+        return refRadius * c
+    end
+end
+
 ## HEX
 @testitem "GeoRegion HEX Layout Tesselation and :hex Pattern (no EO)" tags = [:tesselation] begin
     # NOTE: 
@@ -73,27 +95,24 @@ end
     end
 end
 
-@testitem "GeoRegion HEX Layout Tesselation and :circ Pattern (with EO)" tags = [:tesselation] begin
+@testitem "GeoRegion HEX Layout Tesselation and :circ Pattern (with EO)" tags = [:tesselation] setup=[setup_tessellation] begin
     samplePoints = [LatLon(43.2693, -8.83691), LatLon(43.6057, -8.11563), LatLon(36.808, -5.06421), LatLon(36.792, -2.3703)] # LatLon{WGS84Latest} coordinates
-    corresponding_idxs_points = [1, 2, 121, 122]
-    sampleNgons = [[LatLon(42.9096, -8.83691), LatLon(42.9271, -8.68509), LatLon(42.9779, -8.5479), LatLon(43.0572, -8.43861), LatLon(43.1572, -8.36791), LatLon(43.2682, -8.34287), LatLon(43.3795, -8.36619), LatLon(43.48, -8.43583), LatLon(43.56, -8.54512), LatLon(43.6113, -8.68338), LatLon(43.629, -8.83691), LatLon(43.6113, -8.99044), LatLon(43.56, -9.12869), LatLon(43.48, -9.23798), LatLon(43.3795, -9.30762), LatLon(43.2682, -9.33094), LatLon(43.1572, -9.3059), LatLon(43.0572, -9.23521), LatLon(42.9779, -9.12591), LatLon(42.9271, -8.98872), LatLon(42.9096, -8.83691), LatLon(42.9096, -8.83691)],
-        [LatLon(36.4322, -2.3703), LatLon(36.4498, -2.23211), LatLon(36.5006, -2.10727), LatLon(36.58, -2.00789), LatLon(36.68, -1.94371), LatLon(36.7911, -1.9211), LatLon(36.9024, -1.94247), LatLon(37.0029, -2.00588), LatLon(37.0827, -2.10526), LatLon(37.134, -2.23087), LatLon(37.1517, -2.3703), LatLon(37.134, -2.50974), LatLon(37.0827, -2.63535), LatLon(37.0029, -2.73472), LatLon(36.9024, -2.79814), LatLon(36.7911, -2.8195), LatLon(36.68, -2.7969), LatLon(36.58, -2.73272), LatLon(36.5006, -2.63334), LatLon(36.4498, -2.5085), LatLon(36.4322, -2.3703), LatLon(36.4322, -2.3703)]]
-    corresponding_idxs_ngon = [1, 122]
+    corresponding_idxs = [1, 2, 121, 122]
 
     reg = GeoRegion(; name="Tassellation", admin="Spain")
     centers, ngon = generate_tesselation(reg, 40000, HEX(; pattern=:circ), EO())
 
     @test length(centers) == 122
     for i in eachindex(samplePoints)
-        @test abs(get_lat(centers[corresponding_idxs_points[i]]) - samplePoints[i].lat) < 1e-4
-        @test abs(get_lon(centers[corresponding_idxs_points[i]]) - samplePoints[i].lon) < 1e-4
+        @test haversine(centers[corresponding_idxs[i]], samplePoints[i]) < 10 # 10m is less than 1e-4 radians
     end
 
     @test length(ngon) == 122
-    for i in eachindex(sampleNgons)
-        for v in eachindex(sampleNgons[i])
-            @test abs(get_lat(ngon[corresponding_idxs_ngon[i]][v]) - sampleNgons[i][v].lat) < 1e-4
-            @test abs(get_lon(ngon[corresponding_idxs_ngon[i]][v]) - sampleNgons[i][v].lon) < 1e-4
+    for (i, idx) in enumerate(corresponding_idxs)
+        p1 = samplePoints[i]
+        for p in ngon[idx]
+            # We test that the great circle distance to the resulting ngon points is roughly the target radius
+            @test haversine(p, p1) - 40000 < 10 # 10m is less than 1e-4 radians
         end
     end
 end
@@ -294,27 +313,24 @@ end
     end
 end
 
-@testitem "GeoRegion ICO Layout Tesselation and :hex Pattern (with EO)" tags = [:tesselation] begin
+@testitem "GeoRegion ICO Layout Tesselation and :circ Pattern (with EO)" tags = [:tesselation] setup=[setup_tessellation] begin
     samplePoints = [LatLon(43.5772, -7.50902), LatLon(43.4468, -5.70002), LatLon(36.6657, -3.58858), LatLon(36.285, -5.82463)]
-    corresponding_idxs_points = [1, 2, 103, 104]
-    sampleNgons = [[LatLon(43.2175, -7.50902), LatLon(43.235, -7.35644), LatLon(43.2858, -7.21855), LatLon(43.3651, -7.1087), LatLon(43.4651, -7.03764), LatLon(43.5761, -7.01247), LatLon(43.6874, -7.03589), LatLon(43.7879, -7.10588), LatLon(43.8679, -7.21573), LatLon(43.9192, -7.35469), LatLon(43.9369, -7.50902), LatLon(43.9192, -7.66334), LatLon(43.8679, -7.8023), LatLon(43.7879, -7.91215), LatLon(43.6874, -7.98214), LatLon(43.5761, -8.00557), LatLon(43.4651, -7.9804), LatLon(43.3651, -7.90933), LatLon(43.2858, -7.79948), LatLon(43.235, -7.6616), LatLon(43.2175, -7.50902), LatLon(43.2175, -7.50902)],
-        [LatLon(35.9252, -5.82463), LatLon(35.9428, -5.68733), LatLon(35.9937, -5.56329), LatLon(36.073, -5.46457), LatLon(36.1731, -5.40081), LatLon(36.2841, -5.37836), LatLon(36.3954, -5.3996), LatLon(36.4959, -5.46261), LatLon(36.5757, -5.56134), LatLon(36.627, -5.68612), LatLon(36.6447, -5.82463), LatLon(36.627, -5.96314), LatLon(36.5757, -6.08792), LatLon(36.4959, -6.18665), LatLon(36.3954, -6.24966), LatLon(36.2841, -6.27089), LatLon(36.1731, -6.24845), LatLon(36.073, -6.18469), LatLon(35.9937, -6.08597), LatLon(35.9428, -5.96193), LatLon(35.9252, -5.82463), LatLon(35.9252, -5.82463)]]
-    corresponding_idxs_ngon = [1, 104]
+    corresponding_idxs = [1, 2, 103, 104]
 
     reg = GeoRegion(; name="Tassellation", admin="Spain")
     centers, ngon = generate_tesselation(reg, 40000, ICO(), EO())
 
     @test length(centers) == 104
     for i in eachindex(samplePoints)
-        @test abs(get_lat(centers[corresponding_idxs_points[i]]) - samplePoints[i].lat) < 1e-4
-        @test abs(get_lon(centers[corresponding_idxs_points[i]]) - samplePoints[i].lon) < 1e-4
+        @test haversine(centers[corresponding_idxs[i]], samplePoints[i]) < 10 # 10m is less than 1e-4 radians
     end
 
     @test length(ngon) == 104
-    for i in eachindex(sampleNgons)
-        for v in eachindex(sampleNgons[i])
-            @test abs(get_lat(ngon[corresponding_idxs_ngon[i]][v]) - sampleNgons[i][v].lat) < 1e-4
-            @test abs(get_lon(ngon[corresponding_idxs_ngon[i]][v]) - sampleNgons[i][v].lon) < 1e-4
+    for (i, idx) in enumerate(corresponding_idxs)
+        p1 = samplePoints[i]
+        for p in ngon[idx]
+            # We test that the great circle distance to the resulting ngon points is roughly the target radius
+            @test haversine(p, p1) - 40000 < 10 # 10m is less than 1e-4 radians
         end
     end
 end


### PR DESCRIPTION
This PR generalizes some of the plotting functions and make `plot_geo_poly` work with `BorderGeometry` and `AbstractRegion` inputs as well.

Additionally, when providing colors to plot cell contours, it is possible to skip coloring the contours by passing the `color_contours=false` keyword argument

Finally, it simplifies some internal functions by removing code duplication and overtyping in function signatures. The simplifications did break some tests which relied on exact locations of circle points. Those tests are now actually testing the desired distance from the centroid instead of testing for exact locations of the circle points